### PR TITLE
Support #call yielding to a block argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,32 @@ end
 A "failure" in this context means that the proc either raised an exception or
 timed out.
 
+### Example yielding to a block
+
+As an alternative to initializing the breaker with a block you can
+use a single breaker with different remote calls by invoking call with a block.
+
+```ruby
+class ShapeAPI
+  def initialize
+    @breaker = CircuitBreakage::Breaker.new
+    @breaker.failure_threshold =   3
+    @breaker.duration          =  10
+    @breaker.timeout           = 0.5
+    @service = ShapeService.new
+  end
+
+  def get_square
+    @breaker.call { @service.get_square_widget }
+  end
+
+  def get_circles(count)
+    @breaker.call { @service.get_circles(count) }
+  end
+
+end
+```
+
 ### Slightly More Complex Example in Rails
 
 This example shows one way you might choose to wrap a remote service call in a

--- a/spec/breaker_spec.rb
+++ b/spec/breaker_spec.rb
@@ -9,6 +9,11 @@ module CircuitBreakage
       expect(breaker).to be_a(Breaker)
     end
 
+    it 'initializes without a block' do
+      breaker = Breaker.new
+      expect(breaker).to be_a(Breaker)
+    end
+
     describe '#call' do
       subject { -> { breaker.call(arg) rescue nil} }
       let(:arg) { 'This is an argument.' }
@@ -19,6 +24,21 @@ module CircuitBreakage
         it 'calls the block' do
           # The default block just returns the arg.
           expect(breaker.call(arg)).to eq arg
+        end
+
+        it 'yields the block' do
+          value = breaker.call(arg) do | param |
+            param
+          end
+          expect(value).to eq arg
+        end
+
+        it 'yields the block with dynamic binding variables' do
+          param = 'Felix'
+          value = breaker.call do
+            param.size
+          end
+          expect(value).to eq 'Felix'.size
         end
 
         context 'and the call succeeds' do


### PR DESCRIPTION
I tried this out in my app and it works.  Changes should not introduce compatibility issue.  Basically I just added an optional block argument to `#call` which overrides the instance proc, which is now optional.
