### PR TITLE
Allow callers to trip on or ignore specific exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,15 @@ proc = ->(*args) do
 end
 
 breaker = CircuitBreakage::Breaker.new(proc)
+
+# These options are required.
 breaker.failure_threshold =   3 # only 3 failures before tripping circuit
 breaker.duration          =  10 # 10 seconds before retry
 breaker.timeout           = 0.5 # 500 milliseconds allowed before auto-fail
+
+# These options are, uh, optional.
+breaker.only_trip_on  = [ExpensiveFailureException]
+breaker.never_trip_on = [CheapUnimportantFailureException]
 
 begin
   breaker.call(*some_args)    # args are passed through to the proc


### PR DESCRIPTION
This commit adds specs, docs, and behavior for two new breaker
options:
- only_trip_on: array of types that exceptions must match
  for the breaker to trip
- never_trip_on: array of exception types to re-raise without tripping
  the breaker

The breaker checks the only_trip_on option first; an exception
matching both lists will therefore _not_ trip the breaker.

Thanks to @djspinmonkey for advice and guidance for this change.
